### PR TITLE
SecObserve uses license-expression

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ license expression engine in several projects and products such as:
 - REUSE https://reuse.software/ and https://github.com/fsfe/reuse-tool
 - ScanCode-io https://github.com/aboutcode-org/scancode.io
 - ScanCode-toolkit https://github.com/aboutcode-org/scancode-toolkit
+- SecObserve https://github.com/MaibornWolff/SecObserve
 
 See also for details:
 - https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/


### PR DESCRIPTION
`license-expression` is a great tool. The vulnerability and license management system SecObserve uses it to parse license expressions to be able to apply a license policy to an expression.