### PR TITLE
Fix typo in README.rst for SPDX license list version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ expressions.
 Using boolean logic, license expressions can be tested for equality, containment,
 equivalence and can be normalized or simplified.
 
-It also bundles the SPDX License list (3.20 as of now) and the ScanCode license
+It also bundles the SPDX License list (3.26 as of now) and the ScanCode license
 DB (based on latest ScanCode) to easily parse and validate expressions using
 the license symbols.
 


### PR DESCRIPTION
SDPX license list version is mentioned two times in the README:
- 3.26
- 3.20 (I guess this one is wrong)
I fixed 3.20 to 3.26