### PR TITLE
Do not require wheel for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 50", "wheel"]
+requires = ["setuptools >= 50"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
## What's changed?

setuptools 70.1+ does not need wheel at all, and older versions fetch wheel
when building wheels (but not sdists).

## Related issue

Related: https://github.com/fedora-eln/eln/issues/284

## Checklist

- [x] I understand the problem and implemented the solution using appropriate functions.  
- [ ] I added or updated tests to cover my changes.  
- [ ] I verified my changes by running linting, ensuring all local tests pass, and confirming that CI checks succeed.  
