### PR TITLE
Normalize relation case when combining license expressions

### DIFF
--- a/src/license_expression/__init__.py
+++ b/src/license_expression/__init__.py
@@ -1825,5 +1825,5 @@ def combine_expressions(
     if len(expressions) == 1:
         return expressions[0]
 
-    relation = {"AND": licensing.AND, "OR": licensing.OR}[relation]
+    relation = {"AND": licensing.AND, "OR": licensing.OR}[relation.upper()]
     return relation(*expressions)

--- a/tests/test_license_expression.py
+++ b/tests/test_license_expression.py
@@ -2640,3 +2640,9 @@ class CombineExpressionTest(TestCase):
 
     def test_combine_expressions_with_or_relationship(self):
         assert str(combine_expressions(["mit", "apache-2.0"], "OR")) == "mit OR apache-2.0"
+
+
+def test_combine_expressions_accepts_case_insensitive_relations():
+    for relation in ("and", "And", "AND", "or", "Or", "OR"):
+        result = combine_expressions(["mit", "apache-2.0"], relation=relation)
+        assert str(result) == f"mit {relation.upper()} apache-2.0"


### PR DESCRIPTION
Lowercase and mixed-case relations pass validation but then raise `KeyError` during operator lookup. Normalize the lookup the same way as validation.

Adds coverage for `and` and `or` in lowercase, uppercase, and mixed case.
