### PR TITLE
Recheck remaining tokens after removing an overlapping match

### DIFF
--- a/src/license_expression/_pyahocorasick.py
+++ b/src/license_expression/_pyahocorasick.py
@@ -492,6 +492,7 @@ def filter_overlapping(tokens):
                 else:
                     logger_debug("  del curr_tok smaller overlap:", curr_tok)
                     del tokens[i]
+                    i -= 1
                     break
             j += 1
         i += 1

--- a/tests/test__pyahocorasick.py
+++ b/tests/test__pyahocorasick.py
@@ -17,6 +17,7 @@ import unittest
 
 from license_expression._pyahocorasick import Trie
 from license_expression._pyahocorasick import Token
+from license_expression._pyahocorasick import filter_overlapping
 
 
 class TestTrie(unittest.TestCase):
@@ -315,3 +316,13 @@ class TestTrie(unittest.TestCase):
         ]
 
         assert expected == result
+
+
+def test_filter_overlapping_rechecks_replacement_token():
+    tokens = [Token(0, 1), Token(1, 4), Token(4, 8), Token(10, 11)]
+    assert filter_overlapping(tokens) == [Token(4, 8), Token(10, 11)]
+
+
+def test_filter_overlapping_removes_contained_token_after_replacement():
+    tokens = [Token(0, 1), Token(1, 5), Token(2, 3), Token(8, 9)]
+    assert filter_overlapping(tokens) == [Token(1, 5), Token(8, 9)]


### PR DESCRIPTION
When a longer overlapping token replaces the current token, the loop advances past its new position. This can leave overlapping or contained tokens in the result. Revisit that position before advancing.

Adds regression tests for an overlap chain and a contained token after replacement.
