### PR TITLE
Return warnings for duplicate and empty license aliases

### DIFF
--- a/src/license_expression/__init__.py
+++ b/src/license_expression/__init__.py
@@ -1764,8 +1764,8 @@ def validate_symbols(symbols, validate_keys=False):
         errors.append(f"Invalid key: a key cannot be an expression keyword: {ikw}.")
 
     warnings = []
-    for dupe_alias in sorted(dupe_aliases):
-        errors.append(f"Duplicated or empty aliases ignored for license key: {dupe_alias!r}.")
+    for key in sorted(warning_dupe_aliases):
+        warnings.append(f"Duplicated or empty aliases ignored for license key: {key!r}.")
 
     return warnings, errors
 

--- a/tests/test_license_expression.py
+++ b/tests/test_license_expression.py
@@ -2640,3 +2640,29 @@ class CombineExpressionTest(TestCase):
 
     def test_combine_expressions_with_or_relationship(self):
         assert str(combine_expressions(["mit", "apache-2.0"], "OR")) == "mit OR apache-2.0"
+
+
+def test_validate_symbols_reports_duplicate_and_empty_alias_warnings():
+    symbols = [
+        LicenseSymbol("mit", aliases=["MIT license", "mit license"]),
+        LicenseSymbol("apache-2.0", aliases=[""]),
+    ]
+    warnings, errors = validate_symbols(symbols)
+    assert errors == []
+    assert warnings == [
+        "Duplicated or empty aliases ignored for license key: 'apache-2.0'.",
+        "Duplicated or empty aliases ignored for license key: 'mit'.",
+    ]
+
+
+def test_validate_symbols_keeps_conflicting_aliases_as_errors():
+    warnings, errors = validate_symbols(
+        [
+            LicenseSymbol("mit", aliases=["shared"]),
+            LicenseSymbol("apache-2.0", aliases=["shared"]),
+        ]
+    )
+    assert warnings == []
+    assert errors == [
+        "Invalid duplicated alias pointing to multiple keys: " "shared point to keys: 'apache-2.0'."
+    ]

--- a/tests/test_license_expression.py
+++ b/tests/test_license_expression.py
@@ -2664,5 +2664,5 @@ def test_validate_symbols_keeps_conflicting_aliases_as_errors():
     )
     assert warnings == []
     assert errors == [
-        "Invalid duplicated alias pointing to multiple keys: " "shared point to keys: 'apache-2.0'."
+        "Invalid duplicated alias pointing to multiple keys: shared point to keys: 'apache-2.0'."
     ]


### PR DESCRIPTION
`validate_symbols()` collects duplicate and empty alias warnings but reads the conflicting-alias collection when returning them, appending to errors instead. Return the collected warnings under their license keys.

Adds tests for duplicate and empty aliases, and checks that aliases shared by different licenses remain errors.
